### PR TITLE
Refs #7 - Added support for passworded channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ $config = array(
     "username"          => "examplebot",
     "realname"          => "example IRC Bot",
     "nick"              => "examplebot",
-    "channels"          => array( '#example-channel' ),
-    "channel_passwords" => array( 'password-for-example-channel' ),
+    "channels"          => array(
+                               '#example-channel',
+                               array('$example-channel-2' => 'example-password')
+                           ),
     "admins"            => array( 'example' ),
     "debug"             => true,
     "log"               => __DIR__ . '/bot.log',

--- a/README.md
+++ b/README.md
@@ -51,16 +51,17 @@ Here's a basic example:
 require __DIR__ . '/vendor/autoload.php';
 
 $config = array(
-    "hostname"   => "irc.freenode.net",
-    "servername" => "example.com",
-    "port"       => 6667,
-    "username"   => "examplebot",
-    "realname"   => "example IRC Bot",
-    "nick"       => "examplebot",
-    "channels"   => array( '#example-channel' ),
-    "admins"     => array( 'example' ),
-    "debug"      => true,
-    "log"        => __DIR__ . '/bot.log',
+    "hostname"          => "irc.freenode.net",
+    "servername"        => "example.com",
+    "port"              => 6667,
+    "username"          => "examplebot",
+    "realname"          => "example IRC Bot",
+    "nick"              => "examplebot",
+    "channels"          => array( '#example-channel' ),
+    "channel_passwords" => array( 'password-for-example-channel' ),
+    "admins"            => array( 'example' ),
+    "debug"             => true,
+    "log"               => __DIR__ . '/bot.log',
 );
 
 $bot = new Philip($config);

--- a/src/Philip/Philip.php
+++ b/src/Philip/Philip.php
@@ -274,7 +274,16 @@ class Philip
             $this->config['channels'] = array($this->config['channels']);
         }
 
-        foreach ($this->config['channels'] as $channel) {
+        if (array_key_exists('channel_passwords', $this->config) && !is_array($this->config['channel_passwords'])) {
+            $this->config['channel_passwords'] = array($this->config['channel_passwords']);
+        }
+
+        foreach ($this->config['channels'] as $index => $channel) {
+
+            if (array_key_exists('channel_passwords', $this->config) && array_key_exists($index, $this->config['channel_passwords'])) {
+                $channel = array($channel, $this->config['channel_passwords'][$index]);
+            }
+
             $this->send(Response::join($channel));
         }
     }

--- a/src/Philip/Philip.php
+++ b/src/Philip/Philip.php
@@ -274,14 +274,10 @@ class Philip
             $this->config['channels'] = array($this->config['channels']);
         }
 
-        if (array_key_exists('channel_passwords', $this->config) && !is_array($this->config['channel_passwords'])) {
-            $this->config['channel_passwords'] = array($this->config['channel_passwords']);
-        }
-
         foreach ($this->config['channels'] as $index => $channel) {
 
-            if (array_key_exists('channel_passwords', $this->config) && array_key_exists($index, $this->config['channel_passwords'])) {
-                $channel = array($channel, $this->config['channel_passwords'][$index]);
+            if (is_string($index)) {
+                $channel = array($index, $channel);
             }
 
             $this->send(Response::join($channel));


### PR DESCRIPTION
Some channels have a password requirement that must be sent in during
the join procedure.

Added a 'channel_passwords' config array index that, if present,
supplies the passwords for the channels defined in 'channels'.

The array is a parallel construction with the indices matching the
indices in 'channels'.  If it is omitted, backwards compatability is
preserved.
