### PR TITLE
Add some features to Philip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+
+php:
+    - 5.3
+    - 5.4
+
+before_script:
+    - wget http://getcomposer.org/composer.phar
+    - php composer.phar install --dev
+
+script: vendor/bin/atoum -d tests -nccfns Symfony

--- a/README.md
+++ b/README.md
@@ -51,17 +51,21 @@ Here's a basic example:
 require __DIR__ . '/vendor/autoload.php';
 
 $config = array(
-    "hostname"   => "irc.freenode.net",
-    "servername" => "example.com",
-    "port"       => 6667,
-    "username"   => "examplebot",
-    "realname"   => "example IRC Bot",
-    "nick"       => "examplebot",
-    "password"   => "botpassword",
-    "channels"   => array( '#example-channel' ),
-    "admins"     => array( 'example' ),
-    "debug"      => true,
-    "log"        => __DIR__ . '/bot.log',
+    "hostname"     => "irc.freenode.net",
+    "servername"   => "example.com",
+    "port"         => 6667,
+    "username"     => "examplebot",
+    "realname"     => "example IRC Bot",
+    "nick"         => "examplebot",
+    "password"     => "botpassword",
+    "channels"     => array( '#example-channel' ),
+    "unflood"      => array(
+        "interval" => 500000, // Interval between messages
+        "delay"    => 2000000 // Delay after request handling
+    ),
+    "admins"       => array( 'example' ),
+    "debug"        => true,
+    "log"          => __DIR__ . '/bot.log',
 );
 
 $bot = new Philip($config);

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ $config = array(
     "username"   => "examplebot",
     "realname"   => "example IRC Bot",
     "nick"       => "examplebot",
+    "password"   => "botpassword",
     "channels"   => array( '#example-channel' ),
     "admins"     => array( 'example' ),
     "debug"      => true,

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
         "monolog/monolog": "1.2.*",
         "symfony/event-dispatcher": "2.1.*"
     },
+    "require-dev": {
+        "atoum/atoum": "dev-master"
+    },
     "autoload": {
         "psr-0": {
             "Philip": "src/"

--- a/src/Philip/AbstractPlugin.php
+++ b/src/Philip/AbstractPlugin.php
@@ -46,6 +46,8 @@ abstract class AbstractPlugin
     public function boot(array $config = array())
     {
         $this->config = $config;
+
+        return $this;
     }
 
     /**
@@ -53,5 +55,21 @@ abstract class AbstractPlugin
      */
     public function displayHelp(Event $help)
     {
+    }
+
+    /**
+     * @return \Philip\Philip
+     */
+    public function getBot()
+    {
+        return $this->bot;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfig()
+    {
+        return $this->config;
     }
 }

--- a/src/Philip/AbstractPlugin.php
+++ b/src/Philip/AbstractPlugin.php
@@ -9,6 +9,8 @@
  */
 namespace Philip;
 
+use Philip\IRC\Event;
+
 /**
  * Philip Plugin Abstract
  *
@@ -37,4 +39,11 @@ abstract class AbstractPlugin
      * Init the plugin and start listening to messages
      */
     abstract public function init();
+
+    /**
+     * @param Event $help
+     */
+    public function displayHelp(Event $help)
+    {
+    }
 }

--- a/src/Philip/AbstractPlugin.php
+++ b/src/Philip/AbstractPlugin.php
@@ -20,10 +20,11 @@ use Philip\IRC\Event;
  */
 abstract class AbstractPlugin
 {
-    /**
-     * @var \Philip\Philip
-     */
+    /** @var \Philip\Philip */
     protected $bot;
+
+    /** @var array */
+    protected $config = array();
 
     /**
      * Constructor
@@ -35,10 +36,17 @@ abstract class AbstractPlugin
         $this->bot = $bot;
     }
 
+    abstract public function getName();
+
     /**
      * Init the plugin and start listening to messages
      */
     abstract public function init();
+
+    public function boot(array $config = array())
+    {
+        $this->config = $config;
+    }
 
     /**
      * @param Event $help

--- a/src/Philip/EventListener.php
+++ b/src/Philip/EventListener.php
@@ -46,14 +46,19 @@ class EventListener
     /**
      * Executes the given callback, returns the callback's return value.
      *
-     * @param Event $event The Philip IRC event
+     * @param \Philip\IRC\Event $event The Philip IRC event
+     *
+     * @return mixed
      */
     public function testAndExecute(Event $event)
     {
         if ($this->shouldExecuteCallback($event->getRequest()->getMessage())) {
             $event->setMatches($this->getMatches());
+
             return call_user_func($this->callback, $event);
         }
+
+        return false;
     }
 
     /**
@@ -66,7 +71,7 @@ class EventListener
     private function shouldExecuteCallback($msg)
     {
         if ($this->pattern) {
-            return preg_match($this->pattern, $msg, $this->matches);
+            return (bool) preg_match($this->pattern, $msg, $this->matches);
         }
 
         return true;
@@ -86,4 +91,3 @@ class EventListener
         return array();
     }
 }
-

--- a/src/Philip/IRC/Event.php
+++ b/src/Philip/IRC/Event.php
@@ -22,7 +22,7 @@ class Event extends BaseEvent
     /** @var \Philip\IRC\Request $request The request object for this event */
     private $request;
 
-    /** @var array $responses Array of responses for the event */
+    /** @var \Philip\IRC\Response[] Array of responses for the event */
     private $responses = array();
 
     /** @var array $matches Array of matches for the pattern */
@@ -31,9 +31,9 @@ class Event extends BaseEvent
     /**
      * Constructor.
      *
-     * @param $request
+     * @param \Philip\IRC\Request $request
      */
-    public function __construct($request)
+    public function __construct(Request $request)
     {
         $this->request = $request;
     }
@@ -43,9 +43,11 @@ class Event extends BaseEvent
      *
      * @param array $matches
      */
-    public function setMatches($matches)
+    public function setMatches(array $matches)
     {
         $this->matches = $matches;
+
+        return $this;
     }
 
     /**
@@ -71,17 +73,19 @@ class Event extends BaseEvent
     /**
      * Add a response to the list of responses.
      *
-     * @param $response
+     * @param \Philip\IRC\Response $response
      */
-    public function addResponse($response)
+    public function addResponse(Response $response)
     {
         array_push($this->responses, $response);
+
+        return $this;
     }
 
     /**
      * Get the responses.
      *
-     * @return array
+     * @return \Philip\IRC\Response[]
      */
     public function getResponses()
     {

--- a/src/Philip/IRC/Request.php
+++ b/src/Philip/IRC/Request.php
@@ -17,19 +17,19 @@ namespace Philip\IRC;
  */
 class Request
 {
-    private static $RE_MSG = '/^
-		(?:
-			\:(?P<prefix>
-				(?P<server>[^\s!]*)
-				(?:!~?(?P<user>[^\s]+)@(?P<host>[^\s]+))?
-			)\s+|
-		)
-		(?P<command>[a-zA-Z]+|[0-9]{3})
-		(?:\s+(?P<channel>[#&!+]+[^\x07\x2C\s]{0,200}))?
-		(?:(?P<params>(?:\s+[^:][^\s]*)*))?
-		(?:\s+\:(?P<message>[^\r\n]*))?
-		\r?\n?
-	$/x';
+    const RE_MSG = '/^
+        (?:
+            \:(?P<prefix>
+                (?P<server>[^\s!]*)
+                (?:!~?(?P<user>[^\s]+)@(?P<host>[^\s]+))?
+            )\s+
+        )?
+        (?P<command>[a-zA-Z]+|[0-9]{3})
+        (?:\s+(?P<channel>[#&!+]+[^\x07\x2C\s]{0,200}))?
+        (?:(?P<params>(?:\s+[^:][^\s]*)*))?
+        (?:\s+\:(?P<message>[^\r\n]*))?
+        \r?\n?
+    $/x';
 
     // Member Vars
     private $raw;
@@ -42,7 +42,6 @@ class Request
     private $params;
     private $message;
 
-
     /**
      * Constructor.
      *
@@ -52,81 +51,80 @@ class Request
     {
 		$this->raw = $raw;
         $matches = array();
-        preg_match(self::$RE_MSG, $raw, $matches);
 
-		// Remove newlines and carriage returns
-		$count = count($matches);
-		if ($count) {
-			$this->prefix   = $matches['prefix'];
-			$this->server   = $matches['server'];
-			$this->user     = $matches['user'];
-			$this->host     = $matches['host'];
-			$this->cmd      = $matches['command'];
-			$this->channel  = $matches['channel'];
+        if (preg_match(self::RE_MSG, $raw, $matches)) {
+            $this->prefix   = $matches['prefix'];
+            $this->server   = $matches['server'];
+            $this->user     = $matches['user'];
+            $this->host     = $matches['host'];
+            $this->cmd      = $matches['command'];
+            $this->channel  = $matches['channel'];
 
-			if (!empty($matches['params'])) {
-				$this->params = explode(' ', trim($matches['params']));
-			} else {
-				$this->params = array();
-			}
+            if (!empty($matches['params'])) {
+                $this->params = explode(' ', trim($matches['params']));
+            } else {
+                $this->params = array();
+            }
 
-			if (isset($matches['message'])) {
-				$this->message  = $matches['message'];
-			}
-		}
+            if (isset($matches['message'])) {
+                $this->message  = $matches['message'];
+            }
+        } else {
+            throw new \InvalidArgumentException(sprintf('Invalid command: %s', $raw));
+        }
     }
 
-	/**
-	 * Returns the sent command.
-	 *
-	 * @return string The IRC command in the request
-	 */
+    /**
+     * Returns the sent command.
+     *
+     * @return string The IRC command in the request
+     */
     public function getCommand()
     {
-		return $this->cmd;
-	}
+        return $this->cmd;
+    }
 
-	/**
-	 * Returns the parameters from the request.
-	 *
-	 * @return array The parameters in the request (minus the trailing param)
-	 */
+    /**
+     * Returns the parameters from the request.
+     *
+     * @return array The parameters in the request (minus the trailing param)
+     */
     public function getParams()
     {
-		return $this->params;
-	}
+        return $this->params;
+    }
 
-	/**
-	 * Returns the message portion of the request.
-	 *
-	 * @return string The message/trailing part of the request
-	 */
+    /**
+     * Returns the message portion of the request.
+     *
+     * @return string The message/trailing part of the request
+     */
     public function getMessage()
     {
-		return $this->message;
-	}
+        return $this->message;
+    }
 
-	/**
-	 * Returns the source of the message. If it was a PM, the source
-	 * will be a user's nick. If it was a message in a channel, it'll
-	 * be the channel name.
-	 *
-	 * @return string The sending user's nick, or the channel name
-	 */
+    /**
+     * Returns the source of the message. If it was a PM, the source
+     * will be a user's nick. If it was a message in a channel, it'll
+     * be the channel name.
+     *
+     * @return string The sending user's nick, or the channel name
+     */
     public function getSource()
     {
-		if ($this->isPrivateMessage()) {
-			return $this->getSendingUser();
-		}
+        if ($this->isPrivateMessage()) {
+            return $this->getSendingUser();
+        }
 
-		return $this->channel;
-	}
+        return $this->channel;
+    }
 
-	/**
-	 * Returns the sending user's nick, false otherwise.
-	 *
-	 * @return mixed The sending user's nick, or false if it wasn't sent by a user
-	 */
+    /**
+     * Returns the sending user's nick, false otherwise.
+     *
+     * @return mixed The sending user's nick, or false if it wasn't sent by a user
+     */
     public function getSendingUser()
     {
         if ($this->isFromUser()) {
@@ -143,40 +141,45 @@ class Request
      */
     public function getServer()
     {
-		if ($this->isFromServer()) {
-			return $this->prefix;
-		}
+        if ($this->isFromServer()) {
+            return $this->prefix;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	/**
-	 * Returns true if the message is a private message.
-	 *
-	 * @return bool True if the message is a private one
-	 */
+    /**
+     * Returns true if the message is a private message.
+     *
+     * @return bool True if the message is a private one
+     */
     public function isPrivateMessage()
     {
-		return empty($this->channel);
-	}
+        return empty($this->channel);
+    }
 
-	/**
-	 * Returns true if the message was sent by a user.
-	 *
-	 * @return bool True if the request was from a user, false otherwise
-	 */
+    /**
+     * Returns true if the message was sent by a user.
+     *
+     * @return bool True if the request was from a user, false otherwise
+     */
     public function isFromUser()
     {
-		return !empty($this->user);
-	}
+        return !empty($this->user);
+    }
 
-	/**
-	 * Returns true if the message was sent from a server.
-	 *
-	 * @return bool True if the request was from a server, false otherwise
-	 */
+    /**
+     * Returns true if the message was sent from a server.
+     *
+     * @return bool True if the request was from a server, false otherwise
+     */
     public function isFromServer()
     {
-		return !$this->isFromUser();
-	}
+        return !$this->isFromUser();
+    }
+
+    public function getHost()
+    {
+        return $this->host;
+    }
 }

--- a/src/Philip/IRC/Response.php
+++ b/src/Philip/IRC/Response.php
@@ -17,146 +17,147 @@ namespace Philip\IRC;
  */
 class Response
 {
-	/** @var array $args The IRC command response arguments */
-	private $args;
+    /** @var array $args The IRC command response arguments */
+    private $args;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param string $cmd  The IRC command to return
-	 * @param mixed  $args The arguments to send with it
-	 */
-	private function __construct($cmd, $args = '')
-	{
-		if (!is_array($args)) {
-			$args = array($args);
-		}
+    /**
+     * Constructor.
+     *
+     * @param string $cmd  The IRC command to return
+     * @param mixed  $args The arguments to send with it
+     */
+    public function __construct($cmd, $args = '')
+    {
+        if (!is_array($args)) {
+            $args = array($args);
+        }
 
         $args = array_map(function($x) { return trim($x); }, $args);
-		$end = count($args) - 1;
-		$args[$end] = ':' . $args[$end];
+        $end = count($args) - 1;
+        $args[$end] = ':' . $args[$end];
 
-		$this->args = $args;
-		array_unshift($this->args, strtoupper($cmd));
-	}
+        $this->args = $args;
+        array_unshift($this->args, strtoupper($cmd));
+    }
 
     /**
      * Creates a PONG response.
      *
-     * @param string $host The host string to send back
+     * @param  string   $host The host string to send back
      * @return Response An IRC Response object
      */
-	public static function pong($host)
-	{
+    public static function pong($host)
+    {
         return new self('PONG', $host);
     }
 
     /**
      * Creates a QUIT response.
      *
-     * @param string $msg The quitting message
+     * @param  string   $msg The quitting message
      * @return Response An IRC Response object
      */
-	public static function quit($msg)
-	{
+    public static function quit($msg)
+    {
         return new self('QUIT', $msg);
     }
 
     /**
      * Creates a JOIN response.
      *
-     * @param string $channels The channels to join
+     * @param  string   $channels The channels to join
      * @return Response An IRC Response object
      */
-	public static function join($channels)
-	{
+    public static function join($channels)
+    {
         return new self('JOIN', $channels);
     }
 
     /**
      * Creates a PART response.
      *
-     * @param string $channels The channels to leave
+     * @param  string   $channels The channels to leave
      * @return Response An IRC Response object
      */
-	public static function leave($channels)
-	{
+    public static function leave($channels)
+    {
         return new self('PART', $channels);
     }
 
     /**
      * Creates a PRIVMSG response.
      *
-     * @param string $who  The channel/nick to send this msg to
-     * @param string $what The messages to send
+     * @param  string   $who  The channel/nick to send this msg to
+     * @param  string   $what The messages to send
      * @return Response An IRC Response object
      */
-	public static function msg($who, $what)
-	{
+    public static function msg($who, $what)
+    {
         return new self('PRIVMSG', array($who, $what));
     }
 
-	/**
-	 * Creates a NOTICE response.
-	 *
-	 * @param string $channel The channel to send the notice to.
-	 * @return Response An IRC Response object
-	 */
-	public static function notice($channel, $msg)
-	{
-		return new self('NOTICE', array($channel, $msg));
-	}
+    /**
+     * Creates a NOTICE response.
+     *
+     * @param  string   $channel The channel to send the notice to.
+     * @return Response An IRC Response object
+     */
+    public static function notice($channel, $msg)
+    {
+        return new self('NOTICE', array($channel, $msg));
+    }
 
-	/**
-	 * Creates a ACTION response.
-	 *
-	 * @param string $channel The channel to send the action to.
-	 * @return Response An IRC Response object
-	 */
-	public static function action($channel, $msg)
-	{
-		// ACTION isn't really part of the IRC spec, it's kind of an agreement between client devs.
-		// An ACTION is just a standard PRIVMSG whose message starts with HEX 01 byte, followed by
-		// "ACTION", then the message, and ends with a HEX 01 byte.
-		//
-		// See also:
-		//	http://www.dreamincode.net/forums/topic/85216-irc-action/page__p__535748&#entry535748
-		$msg = "\x01ACTION $msg\x01";
-		return new self('PRIVMSG', array($channel, $msg));
-	}
+    /**
+     * Creates a ACTION response.
+     *
+     * @param  string   $channel The channel to send the action to.
+     * @return Response An IRC Response object
+     */
+    public static function action($channel, $msg)
+    {
+        // ACTION isn't really part of the IRC spec, it's kind of an agreement between client devs.
+        // An ACTION is just a standard PRIVMSG whose message starts with HEX 01 byte, followed by
+        // "ACTION", then the message, and ends with a HEX 01 byte.
+        //
+        // See also:
+        //	http://www.dreamincode.net/forums/topic/85216-irc-action/page__p__535748&#entry535748
+        $msg = "\x01ACTION $msg\x01";
+
+        return new self('PRIVMSG', array($channel, $msg));
+    }
 
     /**
      * Creates a USER response.
      *
-     * @param string $nick     The bot's nickname
-     * @param string $host     The IRC host to connect to
-     * @param string $server   The server name
-     * @param string $realname The bot's "real name"
+     * @param  string   $nick     The bot's nickname
+     * @param  string   $host     The IRC host to connect to
+     * @param  string   $server   The server name
+     * @param  string   $realname The bot's "real name"
      * @return Response An IRC Response object
      */
-	public static function user($nick, $host, $server, $realname)
-	{
+    public static function user($nick, $host, $server, $realname)
+    {
         return new self('USER', array($nick, $host, $server, $realname));
     }
 
     /**
      * Creates a NICK response.
      *
-     * @param string $nick The nickname to set
+     * @param  string   $nick The nickname to set
      * @return Response An IRC Response object
      */
-	public static function nick($nick)
-	{
+    public static function nick($nick)
+    {
         return new self('NICK', $nick);
     }
 
-	/**
-	 * Stringify this object.
-	 *
-	 * @return string The string representation of the response
-	 */
-	public function __toString()
-	{
-		return implode(' ', $this->args);
-	}
+    /**
+     * Stringify this object.
+     *
+     * @return string The string representation of the response
+     */
+    public function __toString()
+    {
+        return implode(' ', $this->args);
+    }
 }

--- a/src/Philip/Philip.php
+++ b/src/Philip/Philip.php
@@ -263,6 +263,13 @@ class Philip
             $this->config['servername'],
             $this->config['realname']
         ));
+
+        if(isset($this->config['password'])) {
+            $this->send(Response::msg(
+                'NickServ',
+                'identify ' . $this->config['password']
+            ));
+        }
     }
 
     /**

--- a/src/Philip/Philip.php
+++ b/src/Philip/Philip.php
@@ -33,10 +33,10 @@ class Philip
     /** @var resource $socket The socket for communicating with the IRC server */
     private $socket;
 
-    /** @var EventDispatcher $dispatcher The event mediator */
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher The event mediator */
     private $dispatcher;
 
-    /** @var Logger $log The log to write to, if debug is enabled */
+    /** @var \Monolog\Logger $log The log to write to, if debug is enabled */
     private $log;
 
     /** @var string $pidfile The location to write to, if write_pidfile is enabled */
@@ -52,11 +52,12 @@ class Philip
      * Constructor.
      *
      * @param array $config The configuration for the bot
+     * @param \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher
      */
-    public function __construct($config = array())
+    public function __construct($config = array(), EventDispatcher $dispatcher = null)
     {
         $this->config = $config;
-        $this->dispatcher = new EventDispatcher();
+        $this->dispatcher = $dispatcher ?: new EventDispatcher();
         $this->initialize();
     }
 
@@ -81,11 +82,15 @@ class Philip
      *
      * @param string   $pattern  The RegEx to test the message against
      * @param callable $callback The callback to run if the pattern matches
+     *
+     * @return \Philip\Philip
      */
     public function onChannel($pattern, $callback)
     {
         $handler = new EventListener($pattern, $callback);
         $this->dispatcher->addListener('message.channel', array($handler, 'testAndExecute'));
+
+        return $this;
     }
 
     /**
@@ -93,11 +98,15 @@ class Philip
      *
      * @param string   $pattern  The RegEx to test the message against
      * @param callable $callback The callback to run if the pattern matches
+     *
+     * @return \Philip\Philip
      */
     public function onPrivateMessage($pattern, $callback)
     {
         $handler = new EventListener($pattern, $callback);
         $this->dispatcher->addListener('message.private', array($handler, 'testAndExecute'));
+
+        return $this;
     }
 
     /**
@@ -105,56 +114,71 @@ class Philip
      *
      * @param string   $pattern  The RegEx to test the message against
      * @param callable $callback The callback to run if the pattern matches
+     *
+     * @return \Philip\Philip
      */
     public function onMessages($pattern, $callback)
     {
-        $handler = new EventListener($pattern, $callback);
-        $this->dispatcher->addListener('message.channel', array($handler, 'testAndExecute'));
-        $this->dispatcher->addListener('message.private', array($handler, 'testAndExecute'));
+        return $this
+            ->onChannel($pattern, $callback)
+            ->onPrivateMessage($pattern, $callback)
+        ;
     }
 
     /**
      * Adds event handlers to the list for JOIN messages.
      *
      * @param callable $callback The callback to run if the pattern matches
+     *
+     * @return \Philip\Philip
      */
     public function onJoin($callback)
     {
-        $handler = new EventListener(null, $callback);
-        $this->dispatcher->addListener('server.join', array($handler, 'testAndExecute'));
+        return $this->onServer('join', $callback);
     }
 
     /**
      * Adds event handlers to the list for PART messages.
      *
      * @param callable $callback The callback to run if the pattern matches
+     *
+     * @return \Philip\Philip
      */
     public function onPart($callback)
     {
-        $handler = new EventListener(null, $callback);
-        $this->dispatcher->addListener('server.part', array($handler, 'testAndExecute'));
+        return $this->onServer('part', $callback);
     }
 
     /**
      * Adds event handlers to the list for ERROR messages.
      *
      * @param callable $callback The callback to run if the pattern matches
+     *
+     * @return \Philip\Philip
      */
     public function onError($callback)
     {
-        $handler = new EventListener(null, $callback);
-        $this->dispatcher->addListener('server.error', array($handler, 'testAndExecute'));
+        return $this->onServer('error', $callback);
     }
 
     /**
      * Adds event handlers to the list for NOTICE messages.
      *
      * @param callable $callback The callback to run if the pattern matches
+     *
+     * @return \Philip\Philip
      */
     public function onNotice($callback)
     {
+        return $this->onServer('notice', $callback);
+    }
+
+    public function onServer($command, $callback)
+    {
         $handler = new EventListener(null, $callback);
-        $this->dispatcher->addListener('server.notice', array($handler, 'testAndExecute'));
+        $this->dispatcher->addListener('server.' . $command, array($handler, 'testAndExecute'));
+
+        return $this;
     }
 
     /**
@@ -197,16 +221,42 @@ class Philip
      * Loads a plugin. See the README for plugin documentation.
      *
      * @param string $name The fully-qualified classname of the plugin to load
+     *
+     * @return \Philip\Philip
      */
     public function loadPlugin(AbstractPlugin $plugin)
     {
         $name = $plugin->getName();
-
         $this->log->addDebug('--- Loading plugin ' . $name . PHP_EOL);
         $plugin->init();
         $this->plugins[$name] = $plugin;
+
+        return $this;
     }
 
+    /**
+     * Loads multiple plugins in a single call.
+     *
+     * @param \Philip\AbstractPlugin[] $plugins The fully-qualified classnames of the plugins to load.
+     *
+     * @return \Philip\Philip
+     */
+    public function loadPlugins(array $plugins)
+    {
+        foreach ($plugins as $plugin) {
+            $this->loadPlugin($plugin);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return AbstractPlugin
+     */
     public function getPlugin($name)
     {
         if (false === isset($this->plugins[$name])) {
@@ -217,24 +267,13 @@ class Philip
     }
 
     /**
-     * Loads multiple plugins in a single call.
-     *
-     * @param \Philip\AbstractPlugin[] $names The fully-qualified classnames of the plugins to load.
-     */
-    public function loadPlugins(array $plugins)
-    {
-        foreach ($plugins as $plugin) {
-            $this->loadPlugin($plugin);
-        }
-    }
-
-    /**
      * Determines if the given user is an admin.
      *
-     * @param string $user The username to test
+     * @param  string  $user The username to test
      * @return boolean True if the user is an admin, false otherwise
      */
-    public function isAdmin($user) {
+    public function isAdmin($user)
+    {
         return in_array($user, $this->config['admins']);
     }
 
@@ -266,6 +305,7 @@ class Philip
     {
         stream_set_blocking(STDIN, 0);
         $this->socket = fsockopen($this->config['hostname'], $this->config['port']);
+
         return (bool) $this->socket;
     }
 
@@ -282,7 +322,7 @@ class Philip
             $this->config['realname']
         ));
 
-        if(isset($this->config['password'])) {
+        if (isset($this->config['password'])) {
             $this->send(Response::msg(
                 'NickServ',
                 'identify ' . $this->config['password']
@@ -347,19 +387,20 @@ class Philip
     /**
      * Convert the raw incoming IRC message into a Request object
      *
-     * @param string $raw The unparsed incoming IRC message
+     * @param  string  $raw The unparsed incoming IRC message
      * @return Request The parsed message
      */
     private function receive($raw)
     {
         $this->log->debug('--> ' . $raw);
+
         return new Request($raw);
     }
 
     /**
      * Actually push data back into the socket (giggity).
      *
-     * @param array $responses The responses to send back to the server
+     * @param string|array $responses The responses to send back to the server
      */
     public function send($responses)
     {
@@ -448,19 +489,22 @@ class Philip
      */
     private function addDefaultHandlers()
     {
+        $log = $this->log;
+
         // When the server PINGs us, just respond with PONG and the server's host
-        $pingHandler = new EventListener(null, function($event) {
-            $event->addResponse(Response::pong($event->getRequest()->getMessage()));
-        });
+        $this->onServer(
+            'ping',
+            function($event) {
+                $event->addResponse(Response::pong($event->getRequest()->getMessage()));
+            }
+        );
 
         // If an Error message is encountered, just log it for now.
-        $log = $this->log;
-        $errorHandler = new EventListener(null, function($event) use ($log) {
-            $log->debug("ERROR: {$event->getRequest()->getMessage()}");
-        });
-
-        $this->dispatcher->addListener('server.ping', array($pingHandler, 'testAndExecute'));
-        $this->dispatcher->addListener('server.error', array($errorHandler, 'testAndExecute'));
+        $this->onError(
+            function($event) use ($log) {
+                $log->debug("ERROR: {$event->getRequest()->getMessage()}");
+            }
+        );
 
         $plugins = & $this->plugins;
         $help = function(Event $event) use (& $plugins) {
@@ -469,7 +513,6 @@ class Philip
             }
         };
 
-        $this->onChannel('/^!help$/', $help);
-        $this->onPrivateMessage('/^!help$/', $help);
+        $this->onMessages('/^!help$/', $help);
     }
 }

--- a/src/Philip/Philip.php
+++ b/src/Philip/Philip.php
@@ -350,6 +350,14 @@ class Philip
             $response .= "\r\n";
             fwrite($this->socket, $response);
             $this->log->debug('<-- ' . $response);
+
+            if (isset($this->config['unflood']['interval'])) {
+                usleep($this->config['unflood']['interval']);
+            }
+        }
+
+        if (isset($this->config['unflood']['delay'])) {
+            usleep($this->config['unflood']['delay']);
         }
     }
 

--- a/src/Philip/Philip.php
+++ b/src/Philip/Philip.php
@@ -45,6 +45,9 @@ class Philip
     /** @var \Philip\AbstractPlugin[] */
     private $plugins = array();
 
+    /** @var bool */
+    private $askStop = false;
+
     /**
      * Constructor.
      *
@@ -331,7 +334,14 @@ class Philip
                     $this->send($responses);
                 }
             }
-        } while (!feof($this->socket));
+        } while (!feof($this->socket) && false === $this->askStop);
+    }
+
+    public function askStop()
+    {
+        $this->askStop = true;
+
+        return $this;
     }
 
     /**

--- a/src/Philip/Philip.php
+++ b/src/Philip/Philip.php
@@ -42,6 +42,9 @@ class Philip
     /** @var string $pidfile The location to write to, if write_pidfile is enabled */
     private $pidfile;
 
+    /** @var \Philip\AbstractPlugin[] */
+    private $plugins = array();
+
     /**
      * Constructor.
      *
@@ -202,6 +205,7 @@ class Philip
             }
 
             $plugin->init();
+            $this->plugins[] = $plugin;
         }
     }
 
@@ -428,5 +432,15 @@ class Philip
 
         $this->dispatcher->addListener('server.ping', array($pingHandler, 'testAndExecute'));
         $this->dispatcher->addListener('server.error', array($errorHandler, 'testAndExecute'));
+
+        $plugins = & $this->plugins;
+        $help = function(Event $event) use (& $plugins) {
+            foreach ($plugins as $plugin) {
+                $plugin->displayHelp($event);
+            }
+        };
+
+        $this->onChannel('/^!help$/', $help);
+        $this->onPrivateMessage('/^!help$/', $help);
     }
 }

--- a/tests/units/Philip/AbstractPlugin.php
+++ b/tests/units/Philip/AbstractPlugin.php
@@ -1,0 +1,49 @@
+<?php
+namespace tests\units\Philip;
+
+use atoum;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class AbstractPlugin extends atoum
+{
+    public function test__construct()
+    {
+        $this
+            ->if($bot = new \Philip\Philip())
+            ->then
+                ->object($object = new \mock\Philip\AbstractPlugin($bot))->isInstanceOf('\\Philip\\AbstractPlugin')
+                ->object($object->getBot())->isIdenticalTo($bot)
+                ->array($object->getConfig())->isEqualTo(array())
+        ;
+    }
+
+    public function testBoot()
+    {
+        $this
+            ->if($bot = new \Philip\Philip())
+            ->and($object = new \mock\Philip\AbstractPlugin($bot))
+            ->then
+                ->object($object->boot())->isIdenticalTo($object)
+                ->array($object->getConfig())->isEqualTo(array())
+            ->if($config = array(uniqid() => uniqid()))
+            ->then
+                ->object($object->boot($config))->isIdenticalTo($object)
+                ->array($object->getConfig())->isEqualTo($config)
+        ;
+    }
+
+    public function testGetConfig()
+    {
+        $this
+            ->if($bot = new \Philip\Philip())
+            ->and($object = new \mock\Philip\AbstractPlugin($bot))
+            ->then
+                ->array($object->getConfig())->isEqualTo(array())
+            ->if($config = array(uniqid() => uniqid()))
+            ->and($object->boot($config))
+            ->then
+                ->array($object->getConfig())->isEqualTo($config)
+        ;
+    }
+}

--- a/tests/units/Philip/EventListener.php
+++ b/tests/units/Philip/EventListener.php
@@ -1,0 +1,43 @@
+<?php
+namespace tests\units\Philip;
+
+use atoum;
+use Philip\EventListener as TestedClass;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class EventListener extends atoum
+{
+    public function test__construct()
+    {
+        $this
+            ->if($pattern = uniqid())
+            ->and($callback = function() {})
+            ->then
+                ->object(new TestedClass($pattern, $callback))
+        ;
+    }
+
+    public function testTestAndExecute()
+    {
+        $this
+            ->if($pattern = '/^$/')
+            ->and($result = uniqid())
+            ->and($callback = function() use($result) { return $result; })
+            ->and($this->mockGenerator->shuntParentClassCalls())
+            ->and($request = new \mock\Philip\IRC\Request(uniqid()))
+            ->and($this->mockGenerator->unshuntParentClassCalls())
+            ->and($event = new \mock\Philip\IRC\Event($request))
+            ->and($this->calling($request)->getMessage = $message = uniqid())
+            ->and($object = new TestedClass($pattern, $callback))
+            ->then
+                ->boolean($object->testAndExecute($event))->isFalse()
+            ->if($pattern = '/.*/')
+            ->and($object = new TestedClass($pattern, $callback))
+            ->then
+                ->variable($object->testAndExecute($event))->isIdenticalTo($result)
+                ->mock($event)
+                    ->call('setMatches')->withArguments(array())->once()
+        ;
+    }
+}

--- a/tests/units/Philip/IRC/Event.php
+++ b/tests/units/Philip/IRC/Event.php
@@ -1,0 +1,98 @@
+<?php
+namespace tests\units\Philip\IRC;
+
+use atoum;
+use Philip\IRC\Event as TestedClass;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+class Event extends atoum
+{
+    public function testConstruct()
+    {
+        $this
+            ->if($this->mockGenerator->shuntParentClassCalls())
+            ->and($request = new \mock\Philip\IRC\Request($raw = uniqid()))
+            ->then
+                ->object($object = new TestedClass($request))->isInstanceOf('\\Philip\\IRC\\Event')
+                ->array($object->getMatches())->isEmpty()
+                ->array($object->getResponses())->isEmpty()
+        ;
+    }
+
+    public function testSetMatches()
+    {
+        $this
+            ->if($this->mockGenerator->shuntParentClassCalls())
+            ->and($request = new \mock\Philip\IRC\Request($raw = uniqid()))
+            ->and($object = new TestedClass($request))
+            ->and($matches = array(uniqid(), uniqid()))
+            ->then
+                ->object($object->setMatches($matches))->isIdenticalTo($object)
+                ->array($object->getMatches())->isEqualTo($matches)
+        ;
+    }
+
+    public function testGetMatches()
+    {
+        $this
+            ->if($this->mockGenerator->shuntParentClassCalls())
+            ->and($request = new \mock\Philip\IRC\Request($raw = uniqid()))
+            ->and($object = new TestedClass($request))
+            ->and($matches = array(uniqid(), uniqid()))
+            ->then
+                ->array($object->getMatches())->isEqualTo(array())
+            ->if($object->setMatches($matches))
+            ->then
+                ->array($object->getMatches())->isEqualTo($matches)
+        ;
+    }
+
+    public function testGetRequest()
+    {
+        $this
+            ->if($this->mockGenerator->shuntParentClassCalls())
+            ->and($request = new \mock\Philip\IRC\Request($raw = uniqid()))
+            ->and($object = new TestedClass($request))
+            ->then
+                ->object($object->getRequest())->isIdenticalTo($request)
+        ;
+    }
+
+    public function testAddResponse()
+    {
+        $this
+            ->if($this->mockGenerator->shuntParentClassCalls())
+            ->and($request = new \mock\Philip\IRC\Request($raw = uniqid()))
+            ->and($response = new \Philip\IRC\Response(uniqid()))
+            ->and($object = new TestedClass($request))
+            ->then
+                ->object($object->addResponse($response))->isIdenticalTo($object)
+                ->array($object->getResponses())->isEqualTo(array($response))
+            ->if($otherResponse = new \Philip\IRC\Response(uniqid()))
+            ->and($object->addResponse($otherResponse))
+            ->then
+                ->array($object->getResponses())->isEqualTo(array($response, $otherResponse))
+        ;
+    }
+
+    public function testGetResponses()
+    {
+        $this
+            ->if($this->mockGenerator->shuntParentClassCalls())
+            ->and($request = new \mock\Philip\IRC\Request($raw = uniqid()))
+            ->and($object = new TestedClass($request))
+            ->and($matches = array(uniqid(), uniqid()))
+            ->then
+                ->array($object->getResponses())->isEmpty()
+            ->if($response = new \Philip\IRC\Response(uniqid()))
+            ->and($object->addResponse($response))
+            ->then
+                ->array($object->getResponses())->isEqualTo(array($response))
+            ->if($otherResponse = new \Philip\IRC\Response(uniqid()))
+            ->and($object->addResponse($otherResponse))
+            ->then
+                ->array($object->getResponses())->isEqualTo(array($response, $otherResponse))
+        ;
+    }
+}

--- a/tests/units/Philip/IRC/Request.php
+++ b/tests/units/Philip/IRC/Request.php
@@ -1,0 +1,63 @@
+<?php
+namespace tests\units\Philip\IRC;
+
+use atoum;
+use Philip\IRC\Request as TestedClass;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+class Request extends atoum
+{
+    public function testClass()
+    {
+        $this
+            ->string(TestedClass::RE_MSG)->isNotEmpty()
+        ;
+    }
+
+    public function testConstruct()
+    {
+        $this
+            ->if($command = uniqid())
+            ->then
+                ->exception(function() use($command) {
+                    new TestedClass($command);
+                })
+                    ->isInstanceOf('\\InvalidArgumentException')
+                    ->hasMessage(sprintf('Invalid command: %s', $command))
+            ->if($command = ':username!user@host COMMAND #channel param otherParam :Message')
+            ->then
+                ->object($object = new TestedClass($command))->isInstanceOf('\\Philip\\IRC\\Request')
+                ->boolean($object->isFromServer())->isEqualTo(false)
+                ->boolean($object->isFromUser())->isEqualTo(true)
+                ->boolean($object->getServer())->isEqualTo(false)
+                ->string($object->getSendingUser())->isEqualTo('username')
+                ->string($object->getHost())->isEqualTo('host')
+                ->string($object->getCommand())->isIdenticalTo('COMMAND')
+                ->string($object->getSource())->isEqualTo('#channel')
+                ->array($object->getParams())->isEqualTo(array('param', 'otherParam'))
+                ->string($object->getMessage())->isEqualTo('Message')
+            ->if($command = ':server.name COMMAND param otherParam :Message')
+            ->then
+                ->object($object = new TestedClass($command))->isInstanceOf('\\Philip\\IRC\\Request')
+                ->boolean($object->isFromServer())->isEqualTo(true)
+                ->boolean($object->isFromUser())->isEqualTo(false)
+                ->boolean($object->getSendingUser())->isEqualTo(false)
+                ->boolean($object->getSource())->isEqualTo(false)
+                ->boolean($object->getSource())->isEqualTo(false)
+                ->string($object->getServer())->isEqualTo('server.name')
+                ->string($object->getHost())->isEmpty()
+                ->string($object->getCommand())->isIdenticalTo('COMMAND')
+                ->array($object->getParams())->isEqualTo(array('param', 'otherParam'))
+                ->string($object->getMessage())->isEqualTo('Message')
+            ->if($command = ':username!user@host COMMAND #channel :Message')
+            ->then
+                ->object($object = new TestedClass($command))->isInstanceOf('\\Philip\\IRC\\Request')
+                ->array($object->getParams())->isEmpty()
+            ->if($command = ':server.name COMMAND :Message')
+            ->then
+                ->object($object = new TestedClass($command))->isInstanceOf('\\Philip\\IRC\\Request')
+                ->array($object->getParams())->isEmpty()
+        ;
+    }
+}

--- a/tests/units/Philip/IRC/Response.php
+++ b/tests/units/Philip/IRC/Response.php
@@ -1,0 +1,34 @@
+<?php
+namespace tests\units\Philip\IRC;
+
+use atoum;
+use Philip\IRC\Response as TestedClass;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+class Response extends atoum
+{
+    public function testClass()
+    {
+        $this
+            ->castToString(TestedClass::pong($host = uniqid()))
+                ->isEqualTo('PONG :' . $host)
+            ->castToString(TestedClass::quit($message = uniqid()))
+                ->isEqualTo('QUIT :' . $message)
+            ->castToString(TestedClass::join($channel = '#' . uniqid()))
+                ->isEqualTo('JOIN :' . $channel)
+            ->castToString(TestedClass::leave($channel))
+                ->isEqualTo('PART :' . $channel)
+            ->castToString(TestedClass::msg($who = uniqid(), $message))
+                ->isEqualTo('PRIVMSG ' . $who . ' :' . $message)
+            ->castToString(TestedClass::notice($channel, $message))
+                ->isEqualTo('NOTICE ' . $channel . ' :' . $message)
+            ->castToString(TestedClass::action($channel, $message))
+                ->isEqualTo('PRIVMSG ' . $channel . ' :' . "\x01ACTION " . $message . "\x01")
+            ->castToString(TestedClass::user($nick = uniqid(), $host = uniqid(), $server = uniqid(), $name = uniqid()))
+                ->isEqualTo('USER ' . $nick . ' ' . $host . ' ' . $server . ' :' . $name)
+            ->castToString(TestedClass::nick($nick))
+                ->isEqualTo('NICK :' . $nick)
+        ;
+    }
+}

--- a/tests/units/Philip/Philip.php
+++ b/tests/units/Philip/Philip.php
@@ -1,0 +1,167 @@
+<?php
+namespace tests\units\Philip;
+
+use atoum;
+use Philip\Philip as TestedClass;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class Philip extends atoum
+{
+    public function test__construct()
+    {
+        $this
+            ->if($object = new TestedClass())
+            ->then
+                ->object($object)->isInstanceOf('\\Philip\\Philip')
+                ->array($object->getConfig())->isEqualTo(array())
+                ->object($object->getLogger())->isInstanceOf('\\Monolog\\Logger')
+            ->if($config = array(uniqid() => uniqid()))
+            ->and($object = new TestedClass($config))
+            ->then
+                ->array($object->getConfig())->isIdenticalTo($config)
+        ;
+    }
+
+    public function testOnChannel()
+    {
+        $this
+            ->if($dispatcher = new \mock\Symfony\Component\EventDispatcher\EventDispatcher())
+            ->and($object = new TestedClass(array(), $dispatcher))
+            ->and($pattern = uniqid())
+            ->and($callback = function() {})
+            ->and($listener = new \Philip\EventListener($pattern, $callback))
+            ->then
+                ->object($object->onChannel($pattern, $callback))->isIdenticalTo($object)
+                ->mock($dispatcher)
+                    ->call('addListener')->withArguments('message.channel', array($listener, 'testAndExecute'), 0)->once()
+        ;
+    }
+
+    public function testOnPrivate()
+    {
+        $this
+            ->if($dispatcher = new \mock\Symfony\Component\EventDispatcher\EventDispatcher())
+            ->and($object = new TestedClass(array(), $dispatcher))
+            ->and($pattern = uniqid())
+            ->and($callback = function() {})
+            ->and($listener = new \Philip\EventListener($pattern, $callback))
+            ->then
+                ->object($object->onPrivateMessage($pattern, $callback))->isIdenticalTo($object)
+                ->mock($dispatcher)
+                    ->call('addListener')->withArguments('message.private', array($listener, 'testAndExecute'), 0)->once()
+        ;
+    }
+
+    public function testOnMessages()
+    {
+        $this
+            ->if($object = new \mock\Philip\Philip(array()))
+            ->and($pattern = uniqid())
+            ->and($callback = function() {})
+            ->then
+                ->object($object->onMessages($pattern, $callback))->isIdenticalTo($object)
+                ->mock($object)
+                    ->call('onChannel')->withArguments($pattern, $callback)->once()
+                    ->call('onPrivateMessage')->withArguments($pattern, $callback)->once()
+        ;
+    }
+
+    public function testOnServer()
+    {
+        $this
+            ->if($dispatcher = new \mock\Symfony\Component\EventDispatcher\EventDispatcher())
+            ->and($object = new TestedClass(array(), $dispatcher))
+            ->and($command = uniqid())
+            ->and($callback = function() {})
+            ->and($listener = new \Philip\EventListener(null, $callback))
+            ->then
+                ->object($object->onServer($command, $callback))->isIdenticalTo($object)
+                ->mock($dispatcher)
+                    ->call('addListener')->withArguments('server.' . $command, array($listener, 'testAndExecute'), 0)->once()
+            ->if($command = rand(0, PHP_INT_MAX))
+            ->then
+                ->object($object->onServer($command, $callback))->isIdenticalTo($object)
+                ->mock($dispatcher)
+                    ->call('addListener')->withArguments('server.' . $command, array($listener, 'testAndExecute'), 0)->once()
+        ;
+    }
+
+    public function testOnJoin()
+    {
+        $this
+            ->if($object = new \mock\Philip\Philip(array()))
+            ->and($callback = function() {})
+            ->then
+                ->object($object->onJoin($callback))->isIdenticalTo($object)
+                ->mock($object)
+                    ->call('onServer')->withArguments('join', $callback)->once()
+        ;
+    }
+
+    public function testOnPart()
+    {
+        $this
+            ->if($object = new \mock\Philip\Philip(array()))
+            ->and($callback = function() {})
+            ->then
+                ->object($object->onPart($callback))->isIdenticalTo($object)
+                ->mock($object)
+                    ->call('onServer')->withArguments('part', $callback)->once()
+        ;
+    }
+
+    public function testOnError()
+    {
+        $this
+            ->if($object = new \mock\Philip\Philip(array()))
+            ->and($callback = function() {})
+            ->then
+                ->object($object->onError($callback))->isIdenticalTo($object)
+                ->mock($object)
+                    ->call('onServer')->withArguments('error', $callback)->once()
+        ;
+    }
+
+    public function testOnNotice()
+    {
+        $this
+            ->if($object = new \mock\Philip\Philip())
+            ->and($callback = function() {})
+            ->then
+                ->object($object->onNotice($callback))->isIdenticalTo($object)
+                ->mock($object)
+                    ->call('onServer')->withArguments('notice', $callback)->once()
+        ;
+    }
+
+    public function testLoadPlugin()
+    {
+        $this
+            ->if($object = new TestedClass())
+            ->and($plugin = new \mock\Philip\AbstractPlugin($object))
+            ->and($this->calling($plugin)->getName = $name = uniqid())
+            ->then
+                ->object($object->loadPlugin($plugin))->isIdenticalTo($object)
+                ->mock($plugin)
+                    ->call('getName')->once()
+                ->object($object->getPlugin($name))->isIdenticalTo($plugin)
+        ;
+    }
+
+    public function testLoadPlugins()
+    {
+        $this
+            ->if($object = new \mock\Philip\Philip())
+            ->and($plugin = new \mock\Philip\AbstractPlugin($object))
+            ->and($this->calling($plugin)->getName = $name = uniqid())
+            ->and($otherPlugin = new \mock\Philip\AbstractPlugin($object))
+            ->and($this->calling($otherPlugin)->getName = $otherName = uniqid())
+            ->then
+                ->object($object->loadPlugins(array($plugin, $otherPlugin)))->isIdenticalTo($object)
+                ->mock($object)
+                    ->call('loadPlugin')->withArguments($plugin)->once()
+                    ->call('loadPlugin')->withArguments($otherPlugin)->once()
+        ;
+    }
+}

--- a/tests/units/bootstrap.php
+++ b/tests/units/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../vendor/atoum/atoum/scripts/runner.php';


### PR DESCRIPTION
I reworked my previous PR to have of clean set of commits.

I made a single PR again as these commit are quite related for most of them. The last commit, introducing unit tests, implies everything before is merged so I kept everything together.

If you think come commit might be useless, let me know and I'll remove them from the PR, fixing the tests at the same time.

This PR adds some new features to Philip:
- NickServ authentication (5cefa8011e1af0ec0f5b3b069ea036e5d35426e3) : this allows Philip to identify on networks using NickServ (using the `/msg NickServ identify` command)
- A basic flood control (ba5af9a) : this allows user to configure delays used by Philip when sending message. These settings will avoid Philip getting flood notice.
- An API for plugin to display help messages (ccf63d8) : by providing a standard interface which is called by Philip when invoking the `!help`command.
- Add a gracefull stop (ad2c4bb)

Philip's core has also been a bit reworked to:
- Make the `Request` as close as possible to the RFC (https://tools.ietf.org/html/rfc1459#section-2.3.1)
- Ease unit testing introduced in 9e79de2 with atoum (https://github.com/atoum/atoum)
- Allow plugins to access each others (8bdf186) : this is to access plugins exposing a service (storage, auth, ...)

There is a tiny BC break since 8bdf186e36be053a60a9676826abcbc32cf83eae:

```
<?php
// BEFORE

$bot = new \Philip\Philip();
$bot->loadPlugin('\\Name\\Of\\The\\Plugin\\Class');

// AFTER

$bot = new \Philip\Philip();
$bot->loadPlugin(new \Name\Of\The\Plugin\Class($bot));
```

This allows code to be simpler and more robust as typehinting is done directly with PHP. It also easy testing ;)
