### PR TITLE
Support SSL connections for IRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ require __DIR__ . '/vendor/autoload.php';
 
 $config = array(
     "server"       => "irc.freenode.net",
-    "port"         => 6667,
+    "port"         => 6697,
+    "ssl"          => true,
     "username"     => "examplebot",
     "realname"     => "example IRC Bot",
     "nick"         => "examplebot",
     "password"     => "password-for-nickserv",
-    "conection_password" => "conection-password",
+    "connection_password" => "connection-password",
     "channels"     => array( '#example-channel' ),
     "unflood"      => 500,
     "admins"       => array( 'example' ),

--- a/src/Philip/Philip.php
+++ b/src/Philip/Philip.php
@@ -299,8 +299,13 @@ class Philip
      */
     private function connect()
     {
+        $server = $this->config['server'];
+        if (isset($this->config['ssl']) && $this->config['ssl'] == true) {
+            $server = 'ssl://' . $server;
+        }
+
         stream_set_blocking(STDIN, 0);
-        $this->socket = fsockopen($this->config['server'], $this->config['port']);
+        $this->socket = fsockopen($server, $this->config['port']);
 
         return (bool) $this->socket;
     }


### PR DESCRIPTION
This pull request adds support for an "ssl" configuration property. When set to boolean `true`, this property uses SSL for communication over the socket.
