### PR TITLE
Add PHP 5.5 to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 5.3
     - 5.4
+    - 5.5
 
 before_script:
     - wget http://getcomposer.org/composer.phar


### PR DESCRIPTION
Added PHP 5.5 to .travis.yml

This adds testing under PHP5.5 via TravisCI
