### PR TITLE
Added priority support to event listeners.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ between the two is that you can tell Philip to conditionally respond to message 
 bot will always respond to server events, the API for those is simpler:
 
 ```php
-$bot->on<Event>(<callback function>);
+$bot->on<Event>(<callback function>[, <priority>]);
 ```
 
 Possible values for &lt;Event&gt; in this case are: `Join`, `Part`, `Error`, and `Notice`.
@@ -143,7 +143,7 @@ you will supply a regular expression that Philip will test against. If the regex
 then Philip will execute the callback function you provide. The API for message events is:
 
 ```php
-$bot->on<Event>(<regex pattern>, <callback function>);
+$bot->on<Event>(<regex pattern>, <callback function>[, <priority>]);
 ```
 
 Possible values for &lt;Event&gt; include `Channel`, `PrivateMessage`, and `Message`.
@@ -171,6 +171,10 @@ through the event.
 If your regular expression is successfully matched, Philip will execute the callback function you provide,
 allowing you to respond to the message. The `<callback function>` is an anonymous function that accepts
 one parameter: `$event`.
+
+Setting the `<priority>` is optional. In case a event matches multiple callback functions, the one with
+the highest priority is executed first. If priority is not set, the default value (0) will be used.
+If multiple callbacks have the same priority, they are executed in the order they where added.
 
 `$event` is an instance of `Philip\IRC\Event` (which is a simple wrapper over an IRC "event"). The
 main functions in the public API for a Philip Event re:

--- a/src/Philip/Philip.php
+++ b/src/Philip/Philip.php
@@ -82,13 +82,14 @@ class Philip
      *
      * @param string   $pattern  The RegEx to test the message against
      * @param callable $callback The callback to run if the pattern matches
+     * @param integer  $priority The priority of this event handler
      *
      * @return \Philip\Philip
      */
-    public function onChannel($pattern, $callback)
+    public function onChannel($pattern, $callback, $priority = 0)
     {
         $handler = new EventListener($pattern, $callback);
-        $this->dispatcher->addListener('message.channel', array($handler, 'testAndExecute'));
+        $this->dispatcher->addListener('message.channel', array($handler, 'testAndExecute'), $priority);
 
         return $this;
     }
@@ -98,13 +99,14 @@ class Philip
      *
      * @param string   $pattern  The RegEx to test the message against
      * @param callable $callback The callback to run if the pattern matches
+     * @param integer  $priority The priority of this event handler
      *
      * @return \Philip\Philip
      */
-    public function onPrivateMessage($pattern, $callback)
+    public function onPrivateMessage($pattern, $callback, $priority = 0)
     {
         $handler = new EventListener($pattern, $callback);
-        $this->dispatcher->addListener('message.private', array($handler, 'testAndExecute'));
+        $this->dispatcher->addListener('message.private', array($handler, 'testAndExecute'), $priority);
 
         return $this;
     }
@@ -114,14 +116,15 @@ class Philip
      *
      * @param string   $pattern  The RegEx to test the message against
      * @param callable $callback The callback to run if the pattern matches
+     * @param integer  $priority The priority of this event handler
      *
      * @return \Philip\Philip
      */
-    public function onMessages($pattern, $callback)
+    public function onMessages($pattern, $callback, $priority = 0)
     {
         return $this
-            ->onChannel($pattern, $callback)
-            ->onPrivateMessage($pattern, $callback)
+            ->onChannel($pattern, $callback, $priority)
+            ->onPrivateMessage($pattern, $callback, $priority)
         ;
     }
 
@@ -129,54 +132,67 @@ class Philip
      * Adds event handlers to the list for JOIN messages.
      *
      * @param callable $callback The callback to run if the pattern matches
+     * @param integer  $priority The priority of this event handler
      *
      * @return \Philip\Philip
      */
-    public function onJoin($callback)
+    public function onJoin($callback, $priority = 0)
     {
-        return $this->onServer('join', $callback);
+        return $this->onServer('join', $callback, $priority);
     }
 
     /**
      * Adds event handlers to the list for PART messages.
      *
      * @param callable $callback The callback to run if the pattern matches
+     * @param integer  $priority The priority of this event handler
      *
      * @return \Philip\Philip
      */
-    public function onPart($callback)
+    public function onPart($callback, $priority = 0)
     {
-        return $this->onServer('part', $callback);
+        return $this->onServer('part', $callback, $priority);
     }
 
     /**
      * Adds event handlers to the list for ERROR messages.
      *
      * @param callable $callback The callback to run if the pattern matches
+     * @param integer  $priority The priority of this event handler
      *
      * @return \Philip\Philip
      */
-    public function onError($callback)
+    public function onError($callback, $priority = 0)
     {
-        return $this->onServer('error', $callback);
+        return $this->onServer('error', $callback, $priority);
     }
 
     /**
      * Adds event handlers to the list for NOTICE messages.
      *
      * @param callable $callback The callback to run if the pattern matches
+     * @param integer  $priority The priority of this event handler
      *
      * @return \Philip\Philip
      */
-    public function onNotice($callback)
+    public function onNotice($callback, $priority = 0)
     {
-        return $this->onServer('notice', $callback);
+        return $this->onServer('notice', $callback, $priority);
     }
 
-    public function onServer($command, $callback)
+    /**
+     * Adds event handler to the list of server messages.
+     *
+     * @param string   $command  Server command to listen to
+     * @param callable $callback The callback to run when event occurs
+     * @param int      $priority The priority of this event handler
+     *
+     * @return $this
+     */
+    public function onServer($command, $callback, $priority = 0)
     {
         $handler = new EventListener(null, $callback);
-        $this->dispatcher->addListener('server.' . $command, array($handler, 'testAndExecute'));
+        $this->dispatcher->addListener('server.' . $command, array($handler, 'testAndExecute'), $priority);
 
         return $this;
     }


### PR DESCRIPTION
Added support for setting priorities to event listeners. This way, if a pattern matches on multiple listeners (or multiple listeners to server events) are executed based on their priority.

This also gives some more use to tell the dispatcher to stop all propagation of the event ($event->stopPropagation();).

This change is fully backwards compatible.

Things changed:
- Priority support
- Code documentation updates
- Readme updated to match changes
