### PR TITLE
update Monolog requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "monolog/monolog": "1.2.*",
+        "monolog/monolog": "1.7.*",
         "symfony/event-dispatcher": "2.1.*"
     },
     "require-dev": {


### PR DESCRIPTION
I'm using Monolog & Philip in a project and need to use Monolog 1.7 to send my Logs to ElasticSearch. I've updated philips requirement for monolog to 1.7 which seems to be working good. I've seen no errors on philips side while writing logs using monolog 1.7
